### PR TITLE
Add production scripts and env variables

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -1,11 +1,13 @@
 const express = require("express")
 const router = express.Router()
 const fs = require("fs")
-const pokes = JSON.parse(fs.readFileSync("pokes.json"))
+const path = require("path")
+const pokes = JSON.parse(fs.readFileSync(path.resolve(__dirname, "./pokes.json")))
 
 router.get("/pokemons", (req, res) => {
     res.send(pokes)
 })
+
 router.get("/pokemons/:pokeId", (req, res) => {
     const pokeId = parseInt(req.params.pokeId)
     const maybePoke = pokes.find(p => p.id === pokeId)

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,1 @@
+VUE_APP_API_URL=http://localhost:3000

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+VUE_APP_API_URL=/api

--- a/frontend/src/components/Home.vue
+++ b/frontend/src/components/Home.vue
@@ -10,11 +10,8 @@
 <script>
     import PokemonGrid from "./PokemonGrid"
     import axios from "axios"
+    const API_URL = process.env.VUE_APP_API_URL
 
-    // const getPokemonData = name => {
-    //     return axios.get(`https://pokeapi.co/api/v2/pokemon/${name}`)
-    //         .then(response => response.data)
-    // }
     export default {
         name: "Home",
         components: {
@@ -26,13 +23,7 @@
             }
         },
         mounted() {
-            axios.get("http://localhost:3000/pokemons")
-                // .then(response => {
-                //     const promises = response.data.results.map(poke => {
-                //         return getPokemonData(poke.name)
-                //     });
-                //     return Promise.all(promises)
-                // })
+            axios.get(`${API_URL}/pokemons`)
                 .then(response => {
                     console.log(response.data)
                     this.pokemons = response.data

--- a/frontend/src/components/PokemonDetail.vue
+++ b/frontend/src/components/PokemonDetail.vue
@@ -67,10 +67,11 @@
 
 <script>
 import axios from "axios";
+const API_URL = process.env.VUE_APP_API_URL
 
 const getPokemonData = id => {
   return axios
-    .get(`http://localhost:3000/pokemons/${id}`)
+    .get(`${API_URL}/pokemons/${id}`)
     .then(response => response.data);
 };
 
@@ -93,6 +94,9 @@ export default {
       return this.pokemon.description;
     },
     number: function() {
+      if (this.pokemon === null || !this.pokemon.id) {
+        return "";
+      }
       let paddedNumber = this.pokemon.id.toString().padStart(3, "0");
       return `#${paddedNumber}`;
     },
@@ -125,6 +129,9 @@ export default {
       return pokemon.ability;
     },
     types: function() {
+      if (this.pokemon == null || !this.pokemon.types) {
+        return []
+      }
       return this.pokemon.types.map(t => t.toLowerCase());
     },
     statVida: function() {

--- a/index.js
+++ b/index.js
@@ -1,9 +1,12 @@
 const path = require("path")
 const express = require("express")
+const api = require("./api/api")
 
 const port = process.env.PORT || 3000
 
 const app = express()
+
+app.use("/api", api)
 
 app.use(express.static("frontend/dist"))
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "postinstall": "cd api && npm install && cd ../frontend && npm install && cd ..",
+    "build": "cd frontend && npm run build && cd ..",
     "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
# Rationale

We're adding the required scripts so heroku con build and start our application.

From a developer's perspective we have 2 projects (api and frontend). Having 2 different projects is a little awkward but it allows hot reload in the frontend, without this, we would need to "build" the site every time we make a change in the frontend.

From heroku's perspective, we have only one main project.
It delegates requests under `/api` to our api express router.
And it delegates everything else to our recently built frontend project.

After creating the scripts, there's one more thing to change.
If we are running on dev, we want to hit our api at `localhost:3000`
If we are running on prod, we want to hit our api with whatever url we have and `api` after that. So if we're running at `takadex.herokuapp.com` our api will be served under `takadex.herokuapp.com/api`
To solve this, I decided to use env variables. When we build the project, vue takes these variables from `.env.development` and `.env.production` and put the values under `process.env.MY_VARIABLE`